### PR TITLE
removed --pretend from option for run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ python project.py run -o part_4_analysis_replicate_averages_command
 
 Additionally, can run the following flags for the  `run` or `submit` commands, controlling the how the jobs are executed or submitted to the HPC:
  - `--parallel=2` : This runs this many jobs in parallel (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.
- - `--pretend` : This is used to output what the submission script will look like, without submitting it to the HPC. 
  - See the `signac` documenation for more information and features.
 
 
@@ -162,6 +161,6 @@ python project.py submit -o part_4_analysis_replicate_averages_command
 
 Additionally, can run the following flags for the  `run` or `submit` commands, controlling the how the jobs are executed or submitted to the HPC:
  - `--bundle=2` : Only available when using `submit`.  This bundles multiple jobs (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.
- - `--parallel=2` : This runs this many jobs in parallel (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.
- - `--pretend` : This is used to output what the submission script will look like, without submitting it to the HPC. 
+  - `--pretend` : Only available when using `submit`.  This is used to output what the submission script will look like, without submitting it to the HPC. 
  - See the `signac` documenation for more information and features.
+ - `--parallel=2` : This runs this many jobs in parallel (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.

--- a/signac_numpy_tutorial/project/README.md
+++ b/signac_numpy_tutorial/project/README.md
@@ -24,9 +24,9 @@ python project.py submit -o <part_x_this_does_a_function_y>
 
 Additionally, can run the following flags for the  `run` or `submit` commands, controlling the how the jobs are executed or submitted to the HPC:
  - `--bundle=2` : Only available when using `submit`.  This bundles multiple jobs (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.
- - `--parallel=2` : This runs this many jobs in parallel (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.
- - `--pretend` : This is used to output what the submission script will look like, without submitting it to the HPC. 
+  - `--pretend` : Only available when using `submit`.  This is used to output what the submission script will look like, without submitting it to the HPC. 
  - See the `signac` documenation for more information and features.
+ - `--parallel=2` : This runs this many jobs in parallel (2 in this case) into a single run or HPC submittion script, auto adjusting the time, CPU cores, etc., based on the total command selections.
 
 
  ## templates directory and hpc_setup.py file


### PR DESCRIPTION
removed --pretend from option for run command, as it is only available for the submit (HPC) commands
