### PR TITLE
added --mem-per-cpu and ntasks and ncpus

### DIFF
--- a/signac_numpy_tutorial/project/project.py
+++ b/signac_numpy_tutorial/project/project.py
@@ -49,25 +49,38 @@ output_avg_std_of_replicates_txt_filename = "output_avg_std_of_replicates_txt_fi
 
 # Set the walltime, memory, and number of CPUs and GPUs needed
 # for each individual job, based on the part/section.
+# *******************************************************
+# *******************  WARNING  ************************* 
+# The "part_X_np_or_ntasks_int" should be 1 for most cases.
+# Setting to a higher value will multiply
+# the CPUs, GPUs, and other parameters by its value 
+# that many cause more resources to be used than expected,
+# which may result in higher HPC or cloud computing costs!
+# *******************************************************
+part_1_np_or_ntasks_int = 1
+part_1_cpus_per_task_int = 1
+part_1_gpus_per_task_int = 0
+part_1_mem_per_cpu_gb = 4
 part_1_walltime_hr = 0.25
-part_1_memory_gb = 4
-part_1_cpu_int = 1
-part_1_gpu_int = 0
 
+part_2_np_or_ntask_int = 1
+part_2_cpus_per_task_int = 1
+part_2_gpus_per_task_int = 0
+part_2_mem_per_cpu_gb = 4
 part_2_walltime_hr = 0.5
-part_2_memory_gb = 4
-part_2_cpu_int = 1
-part_2_gpu_int = 0
 
+part_3_np_or_ntask_int = 1
+part_3_cpus_per_task_int = 1
+part_3_gpus_per_task_int = 1
+part_3_mem_per_cpu_gb = 4
 part_3_walltime_hr = 0.75
-part_3_memory_gb = 4
-part_3_cpu_int = 1
-part_3_gpu_int = 1
 
+part_4_np_or_ntask_int = 1
+part_4_cpus_per_task_int = 1
+part_4_gpus_per_task_int = 0
+part_4_mem_per_cpu_gb = 4
 part_4_walltime_hr = 1
-part_4_memory_gb = 4
-part_4_cpu_int = 1
-part_4_gpu_int = 0
+
 
 # ******************************************************
 # ******************************************************
@@ -107,13 +120,16 @@ def part_1_initial_parameters_completed(job):
 
     return data_written_bool
 
+#"memory": part_1_memory_gb
+
 
 @Project.post(part_1_initial_parameters_completed)
 @Project.operation(directives=
     {
-        "np": part_1_cpu_int,
-        "ngpu": part_1_gpu_int,
-        "memory": part_1_memory_gb,
+        "np": part_1_np_or_ntasks_int,
+        "cpus-per-task": part_1_cpus_per_task_int,
+        "ngpu": part_1_gpus_per_task_int,
+        "mem-per-cpu": part_1_mem_per_cpu_gb,
         "walltime": part_1_walltime_hr,
     }, with_job=True
 )
@@ -188,9 +204,10 @@ def part_2_write_numpy_input_written(job):
 @Project.post(part_2_write_numpy_input_written)
 @Project.operation(directives=
     {
-        "np": part_2_cpu_int,
-        "ngpu": part_2_gpu_int,
-        "memory": part_2_memory_gb,
+        "np": part_2_np_or_ntask_int,
+        "cpus-per-task": part_2_cpus_per_task_int,
+        "ngpu": part_2_gpus_per_task_int,
+        "mem-per-cpu": part_2_mem_per_cpu_gb,
         "walltime": part_2_walltime_hr,
     }, with_job=True
 )
@@ -275,9 +292,10 @@ def part_3b_numpy_calcs_completed_properly(job):
 @Project.post(part_3b_numpy_calcs_completed_properly)
 @Project.operation(directives=
     {
-        "np": part_3_cpu_int,
-        "ngpu": part_3_gpu_int,
-        "memory": part_3_memory_gb,
+        "np": part_3_np_or_ntask_int,
+        "cpus-per-task": part_3_cpus_per_task_int,
+        "ngpu": part_3_gpus_per_task_int,
+        "mem-per-cpu": part_3_mem_per_cpu_gb,
         "walltime": part_3_walltime_hr,
     }, with_job=True, cmd=True
 )
@@ -390,11 +408,12 @@ def part_4_analysis_replica_averages_completed(*jobs):
 @Project.post(part_4_analysis_replica_averages_completed)
 @Project.operation(directives=
      {
-         "np": part_4_cpu_int,
-         "ngpu": part_4_gpu_int,
-         "memory": part_4_memory_gb,
-         "walltime": part_4_walltime_hr,
-     }, aggregator=aggregator.groupby(key=statepoint_without_replicate, sort_by="value_0_int", sort_ascending=False)
+        "np": part_4_np_or_ntask_int,
+        "cpus-per-task": part_4_cpus_per_task_int,
+        "ngpu": part_4_gpus_per_task_int,
+        "mem-per-cpu": part_4_mem_per_cpu_gb,
+        "walltime": part_4_walltime_hr,
+    }, aggregator=aggregator.groupby(key=statepoint_without_replicate, sort_by="value_0_int", sort_ascending=False)
 )
 def part_4_analysis_replicate_averages_command(*jobs):
     # Get the individial averages of the values from each state point,

--- a/signac_numpy_tutorial/project/templates/phoenix.sh
+++ b/signac_numpy_tutorial/project/templates/phoenix.sh
@@ -1,9 +1,10 @@
 {% extends "slurm.sh" %}
 
 {% block header %}
-{% set gpus = operations|map(attribute='directives.ngpu')|sum %}
-{% set memory = operations|map(attribute='directives.memory')|sum %}
-{% set np = operations|map(attribute='directives.np')|sum %}
+{% set gpus = operations|map(attribute='directives.ngpu')|max %}
+{% set mem_per_cpu = operations|map(attribute='directives.mem-per-cpu')|max  %}
+{% set cpus_per_task = operations|map(attribute='directives.cpus-per-task')|max  %}
+
     {{- super () -}}
 
 {% if gpus %}
@@ -17,15 +18,17 @@
 
 #SBATCH -A phx-pace-staff
 #SBATCH -N 1
+#SBATCH --cpus-per-task={{ cpus_per_task }}
 #SBATCH -q inferno
 #SBATCH --output=/dev/null
 #SBATCH --error=/dev/null
+#SBATCH --mem-per-cpu={{ mem_per_cpu }}G
 
 echo  "Running on host" hostname
 echo  "Time is" date
 
 # load any modules here needed for both CPU and GPU versions
-module anaconda3
+module load anaconda3
 
 # Add any modules here needed only for the GPU versions
 {% if gpus %}


### PR DESCRIPTION
The options were added to the files and Slurm scripts:

-  "--mem-per-cpu"  which is used as a typical input

- "--ntasks" This is the number of tasks, not the number of CPUs
-   "--cpus-per-task" which is the way CPUs are added per task